### PR TITLE
Replace squarebrackets with test instruction in shell script

### DIFF
--- a/generate-token.sh
+++ b/generate-token.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-while [[ $# -gt 0 ]]
+while test $# -gt 0
 do
 key="$1"
 


### PR DESCRIPTION
Use a more broadly adopted shell dialect for conditional statements as the square brackets yield syntax errors on some platforms.